### PR TITLE
Generate debug APK (as release needs keys.)

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -2,7 +2,7 @@ name: Flutter
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/flutter-ci ]
   pull_request:
     branches: [ master ]
 
@@ -19,9 +19,9 @@ jobs:
         with:
           flutter-version: '1.20'
       - run: flutter pub get
-      - run: flutter build apk  
+      - run: flutter build apk --debug
        # Upload generated apk to the artifacts.
       - uses: actions/upload-artifact@v1
         with:
-          name: release-apk
-          path: build/app/outputs/apk/release/app-release.apk
+          name: debug-apk
+          path: build/app/outputs/apk/debug/app-debug.apk

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,7 +33,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 29
-
+    ndkVersion "21.3.6528147" // Was needed by CI
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Fixed CI by building debug apk.
Later you can create signing keys for GitHub Releases.